### PR TITLE
WS2-810: Donut Chart custom block description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-.idea/*
+.DS_Store

--- a/config/install/core.entity_form_display.block_content.donut_chart.default.yml
+++ b/config/install/core.entity_form_display.block_content.donut_chart.default.yml
@@ -12,7 +12,7 @@ bundle: donut_chart
 mode: default
 content:
   field_heading:
-    weight: 1
+    weight: 3
     settings:
       size: 60
       placeholder: ''
@@ -20,17 +20,24 @@ content:
     type: string_textfield
     region: content
   field_number:
-    weight: 0
+    weight: 1
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: number
     region: content
   field_text_color:
-    weight: 26
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
-hidden:
-  info: true
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }


### PR DESCRIPTION
From what I could tell, this block was the only one that had the Block Description field set to be disabled. It was also set to the ASURite IDs widget. Moved that field out of the Disabled area, and set it to a Textfield widget. That seemed to be all that was needed.

<img width="753" alt="Screen Shot 2021-08-23 at 2 40 42 PM" src="https://user-images.githubusercontent.com/5995907/130652861-4a75d09e-d696-4af3-a81a-bfef5340bd91.png">

<img width="620" alt="Screen Shot 2021-08-23 at 3 55 30 PM" src="https://user-images.githubusercontent.com/5995907/130652879-1b7028a8-15fb-420f-b39f-8c6fe67b71e6.png">
