### PR TITLE
WS2-1082: Remove markup on format switching.

### DIFF
--- a/config/install/field.field.block_content.text_content.field_formatted_text.yml
+++ b/config/install/field.field.block_content.text_content.field_formatted_text.yml
@@ -5,14 +5,22 @@ dependencies:
     - block_content.type.text_content
     - field.storage.block_content.field_formatted_text
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    basic_html: '0'
+    minimal_format: '0'
+    restricted_html: '0'
+    full_html: '0'
+    plain_text: '0'
 id: block_content.text_content.field_formatted_text
 field_name: field_formatted_text
 entity_type: block_content
 bundle: text_content
 label: 'Formatted Text'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
@duarte-daniela @mlsamuelson this removes the invalid markup which is generated when text formats are switched from Basic HTML to Full HTML.