### PR TITLE
WS2-1130: Only allow the 4:3 media type to be used for Content Image Overlap

### DIFF
--- a/config/install/field.field.block_content.content_image.field_media.yml
+++ b/config/install/field.field.block_content.content_image.field_media.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - block_content.type.content_image
     - field.storage.block_content.field_media
-    - media.type.image
     - media.type.image_block_images
 id: block_content.content_image.field_media
 field_name: field_media
@@ -21,7 +20,6 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
-      image: image
     sort:
       field: _none
       direction: ASC

--- a/webspark_blocks.install
+++ b/webspark_blocks.install
@@ -65,6 +65,13 @@ function webspark_blocks_update_9007(&$sandbox) {
 }
 
 /**
+ * Only allow 4:3 images in the Content Image Overlap block.
+ */
+function webspark_blocks_update_9008(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
This PR is part of a larger fix, see https://asudev.jira.com/browse/WS2-1130 for full scope.

After applying this update, users can expect the following:

- Exiting images that are not 4:3 remain as is
- User can remove the existing image and replace it with a new one, which will be prompted to be cropped at 4:3
- However, if they do not rename the image, Drupal will use the original (incorrect) image (WordPress has this behavior too)