### PR TITLE
WS2-1325: Only allow 16:9 images in the Card and Image block

### DIFF
--- a/config/install/field.field.block_content.card_and_image.field_media.yml
+++ b/config/install/field.field.block_content.card_and_image.field_media.yml
@@ -4,14 +4,13 @@ dependencies:
   config:
     - block_content.type.card_and_image
     - field.storage.block_content.field_media
-    - media.type.image
-    - media.type.image_block_images
+    - media.type.cropped_image_wide
 id: block_content.card_and_image.field_media
 field_name: field_media
 entity_type: block_content
 bundle: card_and_image
 label: Image
-description: 'Recommended image size (W x H): 1200 x 440 px'
+description: 'Recommended image size (W x H): 1400 x 600px'
 required: false
 translatable: true
 default_value: {  }
@@ -20,8 +19,7 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
-      image_block_images: image_block_images
-      image: image
+      cropped_image_wide: cropped_image_wide
     sort:
       field: _none
       direction: ASC

--- a/webspark_blocks.install
+++ b/webspark_blocks.install
@@ -72,6 +72,13 @@ function webspark_blocks_update_9008(&$sandbox) {
 }
 
 /**
+ * Only allow 16:9 images in the Card and Image block.
+ */
+function webspark_blocks_update_9009(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
Part of larger PR, see: https://asudev.jira.com/browse/WS2-1325 for full scope.

After applying this update, the user can expect:

- When using the Card and Image block, there are no longer options to choose a 4:3 or Standard Image.
- New images will crop at 16:9, with a minimum height of 600px.
- Existing images are unaffected. User can remove existing image to replace with new image (must have a new name).