### PR TITLE
WS2-1378: Change Testimonials to only use plain text

### DIFF
--- a/config/install/field.field.paragraph.testimonial.field_formatted_text.yml
+++ b/config/install/field.field.paragraph.testimonial.field_formatted_text.yml
@@ -9,17 +9,15 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    plain_text: plain_text
-    basic_html: '0'
-    restricted_html: '0'
-    full_html: '0'
+    allowed_formats:
+      - plain_text
 id: paragraph.testimonial.field_formatted_text
 field_name: field_formatted_text
 entity_type: paragraph
 bundle: testimonial
 label: 'Formatted Text'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/webspark_blocks.install
+++ b/webspark_blocks.install
@@ -80,9 +80,16 @@ function webspark_blocks_update_9009(&$sandbox) {
 }
 
 /**
- * Add new fields to video hero to match hero options
+ * Add new fields to video hero to match hero options.
  */
 function webspark_blocks_update_9010(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
+ * Change Testimonial paragraph type to only allow plain text and be required.
+ */
+function webspark_blocks_update_9011(&$sandbox) {
   _webspark_blocks_revert_module_config();
 }
 


### PR DESCRIPTION
See: https://asudev.jira.com/browse/WS2-1378

This change makes two changes to the Testimonial paragraph type:

- Testimonial text is now required
- Testimonial only allows plain text