### PR TITLE
WS2-1381: Change the Content Image Overlap block view mode to large

### DIFF
--- a/config/install/core.entity_view_display.block_content.content_image.default.yml
+++ b/config/install/core.entity_view_display.block_content.content_image.default.yml
@@ -55,7 +55,7 @@ content:
     label: hidden
     settings:
       link: true
-      view_mode: default
+      view_mode: large
     third_party_settings: {  }
     type: entity_reference_entity_view
     region: content

--- a/config/install/field.field.block_content.content_image.field_media.yml
+++ b/config/install/field.field.block_content.content_image.field_media.yml
@@ -10,7 +10,7 @@ field_name: field_media
 entity_type: block_content
 bundle: content_image
 label: Image
-description: 'Recommended image size (W x H): 818 x 616 px'
+description: 'Recommended image size (W x H): 1024 x 768px'
 required: false
 translatable: true
 default_value: {  }

--- a/webspark_blocks.install
+++ b/webspark_blocks.install
@@ -95,6 +95,7 @@ function webspark_blocks_update_9011(&$sandbox) {
 
 /**
  * Remove markup on format switching in WYSIWYG.
+ * Change view mode for the Content Image Overlap block to "large".
  */
 function webspark_blocks_update_9012(&$sandbox) {
   _webspark_blocks_revert_module_config();


### PR DESCRIPTION
See: https://asudev.jira.com/browse/WS2-1381

Also updates the descriptive text for the image.