### PR TITLE
WS2-1440: Add media types for field_media in Paragraphs and custom Blocks

### DIFF
--- a/config/install/field.field.block_content.card_and_image.field_media.yml
+++ b/config/install/field.field.block_content.card_and_image.field_media.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - block_content.type.card_and_image
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
     - media.type.cropped_image_wide
+    - media.type.image
+    - media.type.image_block_images
 id: block_content.card_and_image.field_media
 field_name: field_media
 entity_type: block_content
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
       cropped_image_wide: cropped_image_wide
+      image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: image
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.block_content.card_image_and_content.field_media.yml
+++ b/config/install/field.field.block_content.card_image_and_content.field_media.yml
@@ -4,6 +4,8 @@ dependencies:
   config:
     - block_content.type.card_image_and_content
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
     - media.type.image_block_images
 id: block_content.card_image_and_content.field_media
@@ -21,6 +23,8 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.block_content.content_image.field_media.yml
+++ b/config/install/field.field.block_content.content_image.field_media.yml
@@ -4,6 +4,9 @@ dependencies:
   config:
     - block_content.type.content_image
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
+    - media.type.image
     - media.type.image_block_images
 id: block_content.content_image.field_media
 field_name: field_media
@@ -20,6 +23,9 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
+      image: image
     sort:
       field: _none
       direction: ASC

--- a/config/install/field.field.block_content.hero.field_media.yml
+++ b/config/install/field.field.block_content.hero.field_media.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - block_content.type.hero
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
 id: block_content.hero.field_media
 field_name: field_media
 entity_type: block_content
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.block_content.image.field_media.yml
+++ b/config/install/field.field.block_content.image.field_media.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - block_content.type.image
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
 id: block_content.image.field_media
 field_name: field_media
 entity_type: block_content
@@ -19,6 +22,9 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.block_content.image_and_text_block.field_media.yml
+++ b/config/install/field.field.block_content.image_and_text_block.field_media.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - block_content.type.image_and_text_block
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
 id: block_content.image_and_text_block.field_media
 field_name: field_media
 entity_type: block_content
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.block_content.image_background_with_cta.field_media.yml
+++ b/config/install/field.field.block_content.image_background_with_cta.field_media.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - block_content.type.image_background_with_cta
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
 id: block_content.image_background_with_cta.field_media
 field_name: field_media
 entity_type: block_content
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.block_content.testimonial_on_image_background.field_media.yml
+++ b/config/install/field.field.block_content.testimonial_on_image_background.field_media.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - block_content.type.testimonial_on_image_background
     - field.storage.block_content.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
 id: block_content.testimonial_on_image_background.field_media
 field_name: field_media
 entity_type: block_content
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.paragraph.blockquote.field_media.yml
+++ b/config/install/field.field.paragraph.blockquote.field_media.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
     - paragraphs.paragraphs_type.blockquote
 id: paragraph.blockquote.field_media
 field_name: field_media
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.paragraph.card.field_media.yml
+++ b/config/install/field.field.paragraph.card.field_media.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
     - media.type.image_block_images
     - paragraphs.paragraphs_type.card
@@ -21,6 +23,8 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.paragraph.card_degree.field_media.yml
+++ b/config/install/field.field.paragraph.card_degree.field_media.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
     - media.type.image_block_images
     - paragraphs.paragraphs_type.card_degree
@@ -21,6 +23,8 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.paragraph.card_event.field_media.yml
+++ b/config/install/field.field.paragraph.card_event.field_media.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
     - media.type.image_block_images
     - paragraphs.paragraphs_type.card_event
@@ -21,6 +23,8 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.paragraph.card_media.field_media.yml
+++ b/config/install/field.field.paragraph.card_media.field_media.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
     - media.type.image_block_images
     - paragraphs.paragraphs_type.card_media
@@ -21,6 +23,8 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.paragraph.card_story.field_media.yml
+++ b/config/install/field.field.paragraph.card_story.field_media.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
     - media.type.image_block_images
     - paragraphs.paragraphs_type.card_story
@@ -21,6 +23,8 @@ settings:
   handler_settings:
     target_bundles:
       image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none

--- a/config/install/field.field.paragraph.gallery_image.field_media.yml
+++ b/config/install/field.field.paragraph.gallery_image.field_media.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
     - paragraphs.paragraphs_type.gallery_image
 id: paragraph.gallery_image.field_media
 field_name: field_media
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/config/install/field.field.paragraph.testimonial.field_media.yml
+++ b/config/install/field.field.paragraph.testimonial.field_media.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media
+    - media.type.cropped_image_sqare
+    - media.type.cropped_image_wide
     - media.type.image
+    - media.type.image_block_images
     - paragraphs.paragraphs_type.testimonial
 id: paragraph.testimonial.field_media
 field_name: field_media
@@ -19,10 +22,13 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      image_block_images: image_block_images
+      cropped_image_sqare: cropped_image_sqare
+      cropped_image_wide: cropped_image_wide
       image: image
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: image_block_images
 field_type: entity_reference

--- a/webspark_blocks.install
+++ b/webspark_blocks.install
@@ -102,6 +102,13 @@ function webspark_blocks_update_9012(&$sandbox) {
 }
 
 /**
+ * Add media types for field_media in Paragraphs and custom Blocks.
+ */
+function webspark_blocks_update_9013(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
Ticket url: https://asudev.jira.com/browse/WS2-1440
This modification on field_media involves the following paragraphs and blocks : 

```
Paragraphs
	*Testimonial [Image] ✓
	*Gallery Image [Image] ✓
	*Card Story [Cropped image (4:3), Image] ✓
	*Card media [Cropped image (4:3), Image] ✓
	*Card event [Cropped image (4:3), Image] ✓
	*Card degree [Cropped image (4:3), Image] ✓
	*Card [Cropped image (4:3), Image] ✓
	*Blockquote [Image] ✓

Block layout
	*Card and Image [Cropped image wide (16:9)] ✓
	*Card image and content [Cropped image (4:3), Image] ✓
	*Content image overlap [Cropped image (4:3)] ✓
	*Hero [Image] ✓
	*Image [Image] ✓
	*Image And Text Block [Image] ✓
	*Image Background With Call To Action [Image] ✓
	*Testimonial On Image Background [Image] ✓
```