### PR TITLE
WS2-1167 - Article content type updates added in hook_update_N()

### DIFF
--- a/webspark_blocks.install
+++ b/webspark_blocks.install
@@ -116,6 +116,39 @@ function webspark_blocks_update_9014(&$sandbox) {
 }
 
 /**
+ * Updates Article content type with new fields + settings
+ */
+function webspark_blocks_update_9015(&$sandbox) {
+  // Queries for relevant nodes already using that field.
+  $bids = \Drupal::entityQuery('block_content')
+    ->condition('type', 'tabbed_content')
+    ->condition('field_background_color', 'default')
+    ->execute();
+
+  // Unlock the configuration storage.
+  \Drupal::state()->set('configuration_locked', FALSE);
+  $logger = \Drupal::logger('webspark_blocks');
+  // Import new configs from webspark profile
+  \Drupal::service('webspark.config_manager')->importConfigFile('core.base_field_override.node.article.promote');
+  \Drupal::service('webspark.config_manager')->importConfigFile('core.date_format.article_date');
+  \Drupal::service('webspark.config_manager')->importConfigFile('field.field.node.article.field_author');
+  \Drupal::service('webspark.config_manager')->importConfigFile('field.field.node.article.field_byline');
+  \Drupal::service('webspark.config_manager')->importConfigFile('field.field.node.article.field_date_published');
+  \Drupal::service('webspark.config_manager')->importConfigFile('field.storage.node.field_author');
+  \Drupal::service('webspark.config_manager')->importConfigFile('field.storage.node.field_byline');
+  \Drupal::service('webspark.config_manager')->importConfigFile('field.storage.node.field_date_published');
+  // Update existing configs from webspark profile
+  \Drupal::service('webspark.config_manager')->updateConfigFile('core.entity_form_display.node.article.default');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('core.entity_view_display.node.article.default');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('core.entity_view_display.node.article.rss');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('core.entity_view_display.node.article.teaser');
+  \Drupal::service('webspark.config_manager')->updateConfigFile('node.type.article');
+  // Lock the configuration storage.
+  \Drupal::state()->set('configuration_locked', TRUE);
+  $logger->notice("Updated Article content type YMLs");
+}
+
+/**
  * Reverts the module related configuration.
  */
 function _webspark_blocks_revert_module_config() {


### PR DESCRIPTION
Re-imports the Article content type's YML updates.

**Note:** I did individual import/update calls for every updated YML profile because: 
1. The default WS2 method for applying updates (_webspark_blocks_revert_module_config()) didn't work with the profile (maybe because it's not a module?), and more importantly,
2. If that did work, we don't want to revert ALL defaults in the profile set in this project back to their initial state. (It could break any modifications anyone has made to anything managed at the install stage - content type structures, etc.).